### PR TITLE
docs: elaborate project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,167 @@
 # LogiTrack Fleet Management API
 
-A backend API for managing vehicle fleets, routes, GPS tracking, and maintenance in a logistics company operating in Central America. Built with [NestJS](https://nestjs.com/), [MongoDB](https://www.mongodb.com/), and [JWT Authentication](https://jwt.io/).
+LogiTrack provides a comprehensive REST API for managing vehicle fleets, driver check‑ins, GPS events and maintenance records. The project powers logistics operations in Central America and is built with [NestJS](https://nestjs.com/) and [MongoDB](https://www.mongodb.com/).
 
----
+## Table of Contents
 
-## 🚚 Project Overview
+- [Features](#features)
+- [Tech Stack](#tech-stack)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Environment Variables](#environment-variables)
+  - [Run Locally](#run-locally)
+  - [Run Tests](#run-tests)
+- [Project Structure](#project-structure)
+- [Scripts](#scripts)
+- [Usage Examples](#usage-examples)
+- [API Reference](#api-reference)
+- [Contributing](#contributing)
 
-**Client:** LogiTrack Centroamérica  
-**Use Case:** B2B logistics company managing 350+ trucks across El Salvador, Honduras, and Nicaragua.
+## Features
 
-This API centralizes:
+- 🔐 **Authentication** – Email/password and Google OAuth with JWT‑based sessions and role guards (`admin`, `logistics`, `driver`).
+- 🚚 **Vehicle Management** – Register vehicles, update details and track status (`active`, `maintenance`, `retired`).
+- 🗺️ **Routes & GPS** – Assign routes, simulate GPS updates and detect unauthorized deviations.
+- 🛠️ **Maintenance Logs** – Record and retrieve service history for each vehicle.
+- 🕒 **Driver Check‑ins** – Log driver check‑in and check‑out times.
 
-- Vehicle and route management
-- Check-in/out tracking for drivers
-- Real-time GPS event logs (simulated)
-- Maintenance logs per vehicle
-- Role-based access (admin, logistics, driver)
+## Tech Stack
 
-> The system is the foundation for predictive logistics and maintenance powered by future machine learning features.
+- **Framework:** NestJS (TypeScript)
+- **Database:** MongoDB with Mongoose
+- **Authentication:** Passport + JWT
+- **Documentation:** Swagger (`@nestjs/swagger`)
+- **Testing:** Jest
 
----
+## Getting Started
 
-## ⚙️ Tech Stack
+### Prerequisites
 
-- **Backend Framework**: NestJS (TypeScript)
-- **Database**: MongoDB
-- **Authentication**: JWT + Role-based Guards
-- **API Docs**: Swagger (`@nestjs/swagger`)
-- **Testing**: Jest (unit, integration, e2e)
+- Node.js 18+
+- Yarn or npm
+- MongoDB instance
 
----
+### Installation
 
-## 📦 Features
+```bash
+git clone <repository-url>
+cd logitrack
+npm install # or yarn install
+```
 
-### ✅ Authentication
-- Secure login via JWT
-- Role-based access: `admin`, `logistics`, `driver`
+### Environment Variables
 
-### ✅ Vehicle Management
-- Register, update, disable vehicles
-- Track vehicle status (`active`, `maintenance`, `retired`)
+Create a `.env` file at the project root and provide the following variables:
 
-### ✅ Route & GPS
-- Assign scheduled routes with points
-- Simulate real-time GPS updates
-- Detect unauthorized deviations
+```
+MONGODB_URI=mongodb://localhost:27017/logitrack
+JWT_SECRET=your-jwt-secret
+JWT_EXPIRATION=1h
+GOOGLE_MAPS_API_KEY=your-google-maps-key
+PORT=3000
+```
 
-### ✅ Maintenance Logs
-- Track vehicle service records
+### Run Locally
 
-### ✅ Check-ins
-- Record check-in/out timestamps for drivers
+```bash
+npm run start:dev
+```
+
+The API will be available at `http://localhost:3000` and Swagger documentation at `http://localhost:3000/api`.
+
+### Run Tests
+
+```bash
+npm test
+```
+
+## Project Structure
+
+```
+src/
+├── auth/             # Authentication and authorization logic
+├── gps-event/        # GPS event ingestion and monitoring
+├── maps/             # Google Maps integration utilities
+├── maintenance/      # Vehicle maintenance tracking
+├── scheduled-route/  # Route planning modules
+├── vehicle/          # Vehicle CRUD and status management
+├── vehicle-checkin/  # Driver check‑in/check‑out records
+└── users/            # User profiles and roles
+```
+
+## Scripts
+
+Common development scripts:
+
+| Command | Description |
+|---------|-------------|
+| `npm run start:dev` | Start the development server with hot reload |
+| `npm run start:prod` | Run the compiled application |
+| `npm run build` | Compile TypeScript to JavaScript |
+| `npm test` | Execute the unit test suite |
+| `npm run lint` | Run ESLint to check code style |
+
+## Usage Examples
+
+Example login request using curl:
+
+```bash
+curl -X POST http://localhost:3000/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email": "user@example.com", "password": "secret"}'
+```
+
+Retrieve all vehicles:
+
+```bash
+curl -H 'Authorization: Bearer <token>' http://localhost:3000/vehicles
+```
+
+Register a new vehicle:
+
+```bash
+curl -X POST http://localhost:3000/vehicles \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"plate": "P123ABC", "brand": "Toyota", "model": "Hilux"}'
+```
+
+Report a GPS event from a driver:
+
+```bash
+curl -X POST http://localhost:3000/gps-events \
+  -H 'Authorization: Bearer <driver-token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"vehicleId": "<vehicleId>", "scheduledRouteId": "<routeId>", "latitude": 13.69, "longitude": -89.22}'
+```
+
+## API Reference
+
+Key endpoints exposed by the service:
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/auth/register` | Register a new user |
+| POST | `/auth/login` | Authenticate with email and password |
+| GET  | `/vehicles` | List vehicles (requires token) |
+| POST | `/vehicles` | Create a vehicle (admin/logistics only) |
+| GET  | `/vehicles/:id` | Retrieve vehicle details |
+| POST | `/vehicle-checkins` | Record driver check‑ins |
+| GET  | `/scheduled-routes` | Retrieve scheduled routes |
+| POST | `/gps-events` | Report GPS event (driver only) |
+| GET  | `/gps-events` | Query GPS events with filters |
+| GET  | `/gps-events/deviations` | List route deviation events |
+| GET  | `/maintenance` | View maintenance records |
+
+More endpoints and detailed schemas are available through the Swagger UI at `/api` once the server is running.
+
+## Contributing
+
+Contributions are welcome! To propose changes:
+
+1. Fork the repository and create a new branch for your feature or fix.
+2. Run `npm run lint` and `npm test` to ensure quality.
+3. Submit a pull request describing your changes.
+
 


### PR DESCRIPTION
## Summary
- document project structure and common scripts in README
- expand usage examples and API reference with more endpoints
- add contributing instructions

## Testing
- `npm test` *(fails: Cannot find module 'src/gps-event/gps-simulator.service' from 'maps/maps.service.spec.ts'; multiple suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b77cbf4afc832d80c06649f66ed7a9